### PR TITLE
Fix backlink sort order

### DIFF
--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -548,7 +548,7 @@ class Comment extends Model
         $num = $this->subnum ? $this->num.'_'.$this->subnum : $this->num;
 
         if (isset($this->comment_factory->backlinks_arr[$num])) {
-            ksort($this->comment_factory->backlinks_arr[$num], SORT_STRING);
+            ksort($this->comment_factory->backlinks_arr[$num], SORT_NATURAL);
             $array = [];
             foreach ($this->comment_factory->backlinks_arr[$num] as $current_p_num_u => $value) {
                 $build_url = $value['build_url'];


### PR DESCRIPTION
Currently, backlinks are sorted using [`ksort`](https://www.php.net/manual/en/function.ksort.php)'s `SORT_STRING`. This results in incorrect sorting if backlinks happen to roll over:

![](https://user-images.githubusercontent.com/41453973/116774679-16e2e080-aa13-11eb-8dab-498c32b7637f.png)

Backlinks `10235` through `19422` should all go after `9774`, but `SORT_STRING` puts numbers starting in `1` ahead of those starting in `9`. Using `SORT_NATURAL` fixes this, while also handling subnums (i.e. backlinks like `>>100,3` will sort correctly).